### PR TITLE
feat: middleware para redirecionar usuários não-autenticados para a rota de login

### DIFF
--- a/app/Http/Middleware/AuthMiddleware.php
+++ b/app/Http/Middleware/AuthMiddleware.php
@@ -6,7 +6,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class RedirectUnauthenticatedCandidate
+class AuthMiddleware
 {
     /**
      * Redireciona para login se o candidato não estiver autenticado.

--- a/app/Http/Middleware/RedirectIfAuthenticatedCandidate.php
+++ b/app/Http/Middleware/RedirectIfAuthenticatedCandidate.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class RedirectIfAuthenticatedCandidate
+{
+    /**
+     * Redireciona o candidato logado para a dashboard
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (Auth::check()) {
+            $user = Auth::user();
+            if (! empty($user?->isCandidate())) {
+                return redirect()->route('index');
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/RedirectUnauthenticatedCandidate.php
+++ b/app/Http/Middleware/RedirectUnauthenticatedCandidate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RedirectUnauthenticatedCandidate
+{
+    /**
+     * Redireciona para login se o candidato não estiver autenticado.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! auth()->check()) {
+            return redirect()->route('login.candidate');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Livewire/Candidate/Auth/Login.php
+++ b/app/Livewire/Candidate/Auth/Login.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Candidate\Auth;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 use Livewire\Attributes\Validate;
@@ -24,6 +25,13 @@ class Login extends Component
             'password.required' => 'O campo senha é obrigatório.',
             'password.max'      => 'O campo senha deve ter no máximo 255 caracteres.',
         ];
+    }
+
+    public function mount()
+    {
+        if (Auth::check()) {
+            return redirect()->route('index');
+        }
     }
 
     public function login()

--- a/app/Livewire/Candidate/Auth/Login.php
+++ b/app/Livewire/Candidate/Auth/Login.php
@@ -27,6 +27,9 @@ class Login extends Component
         ];
     }
 
+    /**
+     * @return void|RedirectResponse
+     */
     public function mount()
     {
         if (Auth::check()) {
@@ -34,6 +37,9 @@ class Login extends Component
         }
     }
 
+    /**
+     * @return void|RedirectResponse
+     */
     public function login()
     {
         $this->validate();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -29,7 +29,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon $created_at
  * @property Carbon $updated_at
  *
- * @mixin 
+ * @mixin
  */
 class User extends Authenticatable
 {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,10 +3,32 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 
+/**
+ * User model representing authenticated users in the system.
+ *
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property string $linkedin_id
+ * @property string $linkedin_token
+ * @property bool $is_candidate
+ * @property bool $is_recruiter
+ * @property bool $is_admin
+ * @property string|null $avatar
+ * @property string $password
+ * @property string|null $remember_token
+ * @property Carbon|null $email_verified_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * @mixin Builder
+ */
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Http\Middleware\RedirectIfAuthenticatedCandidate;
+use App\Http\Middleware\RedirectUnauthenticatedCandidate;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
@@ -12,7 +14,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app['router']->aliasMiddleware('redirect.authenticated.candidate', RedirectIfAuthenticatedCandidate::class);
+        $this->app['router']->aliasMiddleware('auth.candidate', RedirectUnauthenticatedCandidate::class);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,7 +3,7 @@
 namespace App\Providers;
 
 use App\Http\Middleware\RedirectIfAuthenticatedCandidate;
-use App\Http\Middleware\RedirectUnauthenticatedCandidate;
+use App\Http\Middleware\AuthMiddleware;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
@@ -14,8 +14,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app['router']->aliasMiddleware('redirect.authenticated.candidate', RedirectIfAuthenticatedCandidate::class);
-        $this->app['router']->aliasMiddleware('auth.candidate', RedirectUnauthenticatedCandidate::class);
+
+        $this->app['router']->aliasMiddleware('auth.candidate', AuthMiddleware::class);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,7 +13,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-
         $this->app['router']->aliasMiddleware('auth.candidate', AuthMiddleware::class);
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use App\Http\Middleware\RedirectIfAuthenticatedCandidate;
 use App\Http\Middleware\AuthMiddleware;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,7 +5,6 @@ use App\Http\Controllers\Recruiter\Auth\Register as RegisterRecruiter;
 use App\Livewire\Candidate\Auth\LinkedinCallback;
 use App\Livewire\Candidate\Auth\Login;
 use App\Livewire\Candidate\Auth\Register;
-feat/Add-candidate-middleware-and-routes-integration-for-authentication-and-redirection
 use App\Livewire\Recruiter\Vacancy\CreateVacancy;
 use App\Livewire\Recruiter\Vacancy\EditVacancy;
 use App\Livewire\Recruiter\Vacancy\ListVacancy;

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,9 @@
 
 use App\Http\Controllers\Recruiter\Auth\Login as LoginRecruiter;
 use App\Http\Controllers\Recruiter\Auth\Register as RegisterRecruiter;
+use App\Livewire\Candidate\Auth\LinkedinCallback;
+use App\Livewire\Candidate\Auth\Login;
+use App\Livewire\Candidate\Auth\Register;
 use Illuminate\Support\Facades\Route;
 use Laravel\Socialite\Facades\Socialite;
 
@@ -16,20 +19,27 @@ Route::get('/auth/redirect', function () {
     return Socialite::driver('linkedin')->redirect();
 })->name('auth.linkedin.redirect');
 
-Route::get('/auth/callback', \App\Livewire\Candidate\Auth\LinkedinCallback::class)
+Route::get('/auth/callback', LinkedinCallback::class)
     ->name('auth.linkedin.callback');
 
 Route::prefix('candidate')->group(function () {
-    Route::get('/login', \App\Livewire\Candidate\Auth\Login::class)->name('login.candidate');
+    Route::get('/', function () {
+        return redirect()->route('index');
+    });
+    Route::get('/login', Login::class)
+        ->middleware('redirect.authenticated.candidate')
+        ->name('login.candidate');
 
-    Route::get('/register', \App\Livewire\Candidate\Auth\Register::class)->name('register.candidate');
+    Route::get('/register', Register::class)
+        ->middleware('redirect.authenticated.candidate')
+        ->name('register.candidate');
 
     Route::get('/index', App\Livewire\Candidate\Index::class)
-        ->middleware('auth')
+        ->middleware('auth.candidate')
         ->name('index');
 
     Route::get('/aplications-vacancies', App\Livewire\Candidate\ApplyToVacancy::class)
-        ->middleware('auth')
+        ->middleware('auth.candidate')
         ->name('applications.vacancies');
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,11 +28,9 @@ Route::prefix('candidate')->group(function () {
     });
 
     Route::get('/login', Login::class)
-        ->middleware('redirect.authenticated.candidate')
         ->name('login.candidate');
 
     Route::get('/register', Register::class)
-        ->middleware('redirect.authenticated.candidate')
         ->name('register.candidate');
 
     Route::get('/index', App\Livewire\Candidate\Index::class)

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,7 +26,7 @@ Route::prefix('candidate')->group(function () {
     Route::get('/', function () {
         return redirect()->route('index');
     });
-  
+
     Route::get('/login', Login::class)
         ->middleware('redirect.authenticated.candidate')
         ->name('login.candidate');


### PR DESCRIPTION
resolve: #23 

Adicionei 2 middlewares:

* Alterações em mont() no login.php: redireciona os candidates que quiserem acessar a página de login e register para a rota /candidates/index 

* AithMiddleware: impede que os candidates não autorizados acessem rotas protegidas e os redireciona para candidates/login

Middleware registrado no AppServiceProvider e implementado no arquivo web.php

Extra: annotations na model de user afim de facilitar o uso do  linter.